### PR TITLE
release: develop → master cut for Laravel 13 / PHP 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,13 +34,19 @@
   "minimum-stability": "dev",
   "prefer-stable":     true,
   "require":     {
-    "dreamfactory/df-core": "~1.0",
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-core": "~1.0.4",
     "league/flysystem-ftp": "^3.0",
     "league/flysystem-sftp-v3": "^3.0",
-    "league/flysystem-webdav": "3.1.1"
+    "league/flysystem-webdav": "^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "@stable"
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Security">
+            <directory>tests/Security</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Components/LocalFileSystem.php
+++ b/src/Components/LocalFileSystem.php
@@ -26,6 +26,44 @@ class LocalFileSystem implements FileSystemInterface
     //	Methods
     //*************************************************************************
 
+    /**
+     * Reject zip entry names that would escape the extraction target via
+     * traversal (`..`), absolute paths, drive letters, or null bytes.
+     *
+     * Returns true if the name is unsafe to extract.
+     */
+    public static function zipEntryEscapesTarget(string $name): bool
+    {
+        if ($name === '') {
+            return false; // empty entries skipped by caller
+        }
+        // NUL byte truncates many filesystem APIs
+        if (str_contains($name, "\0")) {
+            return true;
+        }
+        // Absolute path (Unix) or drive-letter (Windows)
+        if ($name[0] === '/' || $name[0] === '\\') {
+            return true;
+        }
+        if (strlen($name) >= 2 && ctype_alpha($name[0]) && $name[1] === ':') {
+            return true;
+        }
+        // Normalize separators and check segment-by-segment for ..
+        $normalized = str_replace('\\', '/', $name);
+        // Collapse any URL-encoded traversal that some unzippers honor
+        $decoded = rawurldecode($normalized);
+        if ($decoded !== $normalized) {
+            // After decode, recheck for traversal
+            $normalized = $decoded;
+        }
+        foreach (explode('/', $normalized) as $segment) {
+            if ($segment === '..') {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public function __construct($root)
     {
         if (empty($root)) {
@@ -842,6 +880,17 @@ class LocalFileSystem implements FileSystemInterface
             if (!empty($drop_path)) {
                 $name = str_ireplace($drop_path, '', $name);
             }
+
+            // ZIP slip: zip entry names that contain '..' segments or
+            // start with '/' / a drive letter would let an extraction
+            // write OUTSIDE the intended container directory. Reject any
+            // entry whose normalized path escapes its target.
+            if (self::zipEntryEscapesTarget($name)) {
+                throw new InternalServerErrorException(
+                    "Refusing to extract zip entry with traversal in name: {$name}"
+                );
+            }
+
             $fullPathName = $path . $name;
             if ('/' === substr($fullPathName, -1)) {
                 $this->createFolder($container, $fullPathName, true, [], false);

--- a/src/Components/LocalFileSystem.php
+++ b/src/Components/LocalFileSystem.php
@@ -920,9 +920,65 @@ class LocalFileSystem implements FileSystemInterface
     private static function asFullPath($name, $includesFiles = false)
     {
         $appendage = ($name ? '/' . ltrim($name, '/') : null);
+        $resolved = static::$root . $appendage;
 
-        return static::$root . $appendage;
-        //return Platform::getStoragePath( $name, true, $includesFiles );
+        // Defense-in-depth: reject paths whose normalized form escapes
+        // the configured root. Without this, callers passing `..` segments
+        // through container/path could read or write outside the storage
+        // boundary even when the upstream resource layer is permissive.
+        // Returns a normalized form when safe.
+        return self::assertWithinRoot($resolved);
+    }
+
+    /**
+     * Reject any path that, after normalization, escapes static::$root.
+     * Used by every file-op call site through asFullPath().
+     *
+     * @throws InternalServerErrorException
+     */
+    private static function assertWithinRoot(string $candidate): string
+    {
+        $root = (string) static::$root;
+        if ($root === '') {
+            return $candidate;
+        }
+        // Lexically normalize: split into segments and resolve `..` and `.`
+        // without touching the filesystem (the file may not exist yet).
+        $normalized = self::lexicallyNormalize($candidate);
+        $rootNormalized = self::lexicallyNormalize($root);
+
+        if ($normalized !== $rootNormalized
+            && !str_starts_with($normalized, rtrim($rootNormalized, '/') . '/')
+        ) {
+            throw new InternalServerErrorException(
+                'File operation refused: path escapes the storage root.'
+            );
+        }
+        return $normalized;
+    }
+
+    /**
+     * Lexical (no-filesystem) path normalization that resolves `.` and
+     * `..` segments. Different from realpath() which fails on missing
+     * files and follows symlinks (the symlink-following is what we want
+     * to AVOID — symlinks are how attackers escape root).
+     */
+    private static function lexicallyNormalize(string $path): string
+    {
+        $isAbsolute = str_starts_with($path, '/') || str_starts_with($path, '\\');
+        $segments = preg_split('#[/\\\\]+#', $path);
+        $stack = [];
+        foreach ($segments as $segment) {
+            if ($segment === '' || $segment === '.') {
+                continue;
+            }
+            if ($segment === '..') {
+                array_pop($stack);
+                continue;
+            }
+            $stack[] = $segment;
+        }
+        return ($isAbsolute ? '/' : '') . implode('/', $stack);
     }
 
     /**

--- a/tests/Security/PathAssemblyTraversalTest.php
+++ b/tests/Security/PathAssemblyTraversalTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace DreamFactory\Core\File\Tests\Security;
+
+use DreamFactory\Core\File\Components\LocalFileSystem;
+use DreamFactory\Core\Exceptions\InternalServerErrorException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security: file-op path assembly must reject `..` traversal even when
+ * the caller supplies it through container/path concatenation.
+ */
+class PathAssemblyTraversalTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Initialize the static $root by constructing the LocalFileSystem.
+        new LocalFileSystem('/var/df/storage');
+    }
+
+    public function testNormalizationCollapsesSafeDots(): void
+    {
+        $reflection = new \ReflectionClass(LocalFileSystem::class);
+        $method = $reflection->getMethod('lexicallyNormalize');
+        $method->setAccessible(true);
+        $this->assertSame('/var/df/storage/foo', $method->invoke(null, '/var/df/storage/./foo'));
+        $this->assertSame('/var/df/storage', $method->invoke(null, '/var/df/storage/foo/..'));
+    }
+
+    public function testTraversalEscapeIsRejected(): void
+    {
+        $reflection = new \ReflectionClass(LocalFileSystem::class);
+        $method = $reflection->getMethod('asFullPath');
+        $method->setAccessible(true);
+
+        $this->expectException(InternalServerErrorException::class);
+        $method->invoke(null, '../../etc/passwd', false);
+    }
+
+    public function testDeepTraversalEscapeIsRejected(): void
+    {
+        $reflection = new \ReflectionClass(LocalFileSystem::class);
+        $method = $reflection->getMethod('asFullPath');
+        $method->setAccessible(true);
+
+        $this->expectException(InternalServerErrorException::class);
+        $method->invoke(null, 'a/b/../../../etc/passwd', false);
+    }
+
+    public function testLegitNestedPathAccepted(): void
+    {
+        $reflection = new \ReflectionClass(LocalFileSystem::class);
+        $method = $reflection->getMethod('asFullPath');
+        $method->setAccessible(true);
+
+        $result = $method->invoke(null, 'docs/2024/report.pdf', true);
+        $this->assertStringStartsWith('/var/df/storage', $result);
+    }
+}

--- a/tests/Security/ZipSlipTest.php
+++ b/tests/Security/ZipSlipTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace DreamFactory\Core\File\Tests\Security;
+
+use DreamFactory\Core\File\Components\LocalFileSystem;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security: extractZipFile() must refuse zip entries whose names would
+ * write outside the extraction target.
+ *
+ * Phase 2 audit found:
+ *
+ *     for ($i = 0; $i < $zip->numFiles; $i++) {
+ *         $name = $zip->getNameIndex($i);
+ *         ...
+ *         $fullPathName = $path . $name;
+ *         ...
+ *         $this->writeFile($container, $fullPathName, $content);
+ *     }
+ *
+ * No traversal validation. A malicious zip with entries like
+ * `../../../etc/passwd` or `/etc/passwd` would write OUTSIDE the
+ * configured storage container — full filesystem write to the
+ * webserver-user-writable surface.
+ *
+ * After the fix, zipEntryEscapesTarget() rejects:
+ *   - any segment equal to ".."
+ *   - absolute paths (leading "/" or "\\")
+ *   - Windows drive-letter paths ("C:...")
+ *   - null bytes
+ *   - URL-encoded traversal (..%2f, %2e%2e/)
+ */
+class ZipSlipTest extends TestCase
+{
+    /**
+     * @dataProvider unsafeEntryProvider
+     */
+    public function testRejectsUnsafeEntry(string $name): void
+    {
+        $this->assertTrue(
+            LocalFileSystem::zipEntryEscapesTarget($name),
+            "Zip entry should be flagged unsafe: {$name}"
+        );
+    }
+
+    public static function unsafeEntryProvider(): array
+    {
+        return [
+            'parent traversal'       => ['../passwd'],
+            'deep traversal'         => ['a/b/../../../etc/passwd'],
+            'leading slash absolute' => ['/etc/passwd'],
+            'leading backslash'      => ['\\Windows\\System32\\evil.exe'],
+            'windows drive letter'   => ['C:/Windows/System32/evil.exe'],
+            'null byte'              => ["safe.txt\0../../etc/passwd"],
+            'url-encoded traversal'  => ['a/..%2F../etc/passwd'],
+            'mixed seps'             => ['a/b\\..\\..\\evil'],
+        ];
+    }
+
+    /**
+     * @dataProvider safeEntryProvider
+     */
+    public function testAcceptsSafeEntry(string $name): void
+    {
+        $this->assertFalse(
+            LocalFileSystem::zipEntryEscapesTarget($name),
+            "Zip entry should be accepted as safe: {$name}"
+        );
+    }
+
+    public static function safeEntryProvider(): array
+    {
+        return [
+            'simple file'     => ['file.txt'],
+            'subdir'          => ['data/file.txt'],
+            'deep subdir'     => ['a/b/c/d.txt'],
+            'with dots in name' => ['my.file.v2.txt'],
+            'with parent dir name' => ['parent_dir/file.txt'],
+            'dot in middle'   => ['a/.b/c'],
+        ];
+    }
+
+    public function testSourceCallsValidatorBeforeWrite(): void
+    {
+        $sourcePath = __DIR__ . '/../../src/Components/LocalFileSystem.php';
+        $this->assertFileExists($sourcePath);
+        $contents = file_get_contents($sourcePath);
+
+        $start = strpos($contents, 'function extractZipFile');
+        $this->assertNotFalse($start);
+        $next = strpos($contents, "\n    /**", $start + 10);
+        $body = substr($contents, $start, $next === false ? null : ($next - $start));
+
+        $this->assertMatchesRegularExpression(
+            '/(self|static)::zipEntryEscapesTarget\s*\(/',
+            $body,
+            'extractZipFile() must call zipEntryEscapesTarget() on each entry name'
+        );
+    }
+}


### PR DESCRIPTION
## Release prep: cut develop into master/main

Releases this package's `develop` line for the upcoming **DreamFactory
Laravel 13 + PHP 8.5** release.

### Verification

The develop HEAD on this branch is the SHA locked into the L13/PHP 8.5
test bundle that the team has been smoking. **Full end-to-end smoke
passed 2026-05-26**: PHP 8.5.5, Laravel 13.11.2, `df:setup` seeders,
admin login → JWT, service-type registration (81 types), Postgres
schema introspection + CRUD, OpenAPI generation.

### Coordinated release PRs

This is one of ~26 coordinated `develop → master/main` PRs opened
together as the release cut. Suggested merge order:

1. **Foundation**: df-core → df-system → df-user → df-database
2. **Connectors**: df-sqldb, df-sqlsrv, df-mongodb, df-oracledb, df-snowflake, df-soap, df-salesforce, df-script
3. **Auth**: df-oauth → df-adldap, df-azure-ad, df-oidc, df-saml
4. **Services**: df-email, df-file, df-cache, df-limits, df-logger, df-scheduler
5. **AI tier**: df-ai → df-ai-chat → df-mcp-server
6. **Admin UI**: df-admin-interface
7. **Host app**: dreamfactory/dreamfactory (released last)

### Customer upgrade path

In-place on Docker / managed Linux packages; blue-green strongly
recommended on Windows + custom-PHP-extension installs. Pre-flight
checklist in the release notes.
